### PR TITLE
CMake: Update version required to 3.17.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This source code is licensed in accordance with the terms specified in
 # the LICENSE file found in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.13.3)
+cmake_minimum_required(VERSION 3.17.3)
 project(thirdparty_sqlite)
 
 option(SQLITE_ENABLE_INSTALL_TARGET "When enabled, will cause the project to create the install targets" OFF)


### PR DESCRIPTION
This updates the version required to the latest stable.

Note: this is the first step needed to then update the CMake version also on the osquery repo.